### PR TITLE
Improve sidebar menu animation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.60.0",
     "recharts": "^3.0.2",
+    "framer-motion": "^11.0.0",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.6",

--- a/frontend/src/components/ui/collapsible.tsx
+++ b/frontend/src/components/ui/collapsible.tsx
@@ -1,9 +1,40 @@
+import * as React from "react"
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+import { AnimatePresence, motion } from "framer-motion"
+
+const CollapsibleContext = React.createContext<{ open: boolean }>({ open: false })
 
 function Collapsible({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  children,
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
-  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+  const [openState, setOpenState] = React.useState(defaultOpen ?? false)
+  const open = openProp !== undefined ? openProp : openState
+
+  const handleOpenChange = React.useCallback(
+    (value: boolean) => {
+      onOpenChange?.(value)
+      if (openProp === undefined) setOpenState(value)
+    },
+    [onOpenChange, openProp]
+  )
+
+  return (
+    <CollapsibleContext.Provider value={{ open }}>
+      <CollapsiblePrimitive.Root
+        data-slot="collapsible"
+        open={open}
+        onOpenChange={handleOpenChange}
+        defaultOpen={defaultOpen}
+        {...props}
+      >
+        {children}
+      </CollapsiblePrimitive.Root>
+    </CollapsibleContext.Provider>
+  )
 }
 
 function CollapsibleTrigger({
@@ -18,13 +49,28 @@ function CollapsibleTrigger({
 }
 
 function CollapsibleContent({
+  children,
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  const { open } = React.useContext(CollapsibleContext)
+
   return (
-    <CollapsiblePrimitive.CollapsibleContent
-      data-slot="collapsible-content"
-      {...props}
-    />
+    <AnimatePresence initial={false}>
+      {open && (
+        <CollapsiblePrimitive.CollapsibleContent asChild forceMount {...props}>
+          <motion.div
+            data-slot="collapsible-content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            style={{ overflow: "hidden" }}
+          >
+            {children}
+          </motion.div>
+        </CollapsiblePrimitive.CollapsibleContent>
+      )}
+    </AnimatePresence>
   )
 }
 

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -77,7 +77,7 @@ export default function AppLayout({
                   <CollapsibleTrigger asChild>
                     <SidebarMenuButton tooltip="Lumenosity">
                       <Aperture className="h-4 w-4" />
-                      <span className="text-base">Lumenosity</span>
+                      <span className="text-lg">Lumenosity</span>
                       <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                     </SidebarMenuButton>
                   </CollapsibleTrigger>
@@ -142,7 +142,7 @@ export default function AppLayout({
                   <CollapsibleTrigger asChild>
                     <SidebarMenuButton tooltip="LumenScape">
                       <LayoutGrid className="h-4 w-4" />
-                      <span className="text-base">LumenScape</span>
+                      <span className="text-lg">LumenScape</span>
                       <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                     </SidebarMenuButton>
                   </CollapsibleTrigger>
@@ -223,7 +223,7 @@ export default function AppLayout({
                   <CollapsibleTrigger asChild>
                     <SidebarMenuButton tooltip="LumenCredits">
                       <BadgeDollarSign className="h-4 w-4" />
-                      <span className="text-base">LumenCredits</span>
+                      <span className="text-lg">LumenCredits</span>
                       <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                     </SidebarMenuButton>
                   </CollapsibleTrigger>
@@ -272,7 +272,7 @@ export default function AppLayout({
                   <CollapsibleTrigger asChild>
                     <SidebarMenuButton tooltip="System">
                       <Settings className="h-4 w-4" />
-                      <span className="text-base">System</span>
+                      <span className="text-lg">System</span>
                       <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                     </SidebarMenuButton>
                   </CollapsibleTrigger>


### PR DESCRIPTION
## Summary
- bump sidebar category labels to `text-lg`
- add framer-motion dependency
- animate submenu open/close with framer-motion

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68807764ab54832d8b61a2bef03eab8f