### PR TITLE
Change Material Flow Tracer header color

### DIFF
--- a/frontend/src/components/data-table.tsx
+++ b/frontend/src/components/data-table.tsx
@@ -292,7 +292,7 @@ export function DataTable({
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow
                 key={headerGroup.id}
-                className="bg-lime-300 text-primary text-xs font-semibold uppercase tracking-wider shadow-sm"
+                className="bg-[#204936] text-primary text-xs font-semibold uppercase tracking-wider shadow-sm"
               >
                 {headerGroup.headers.map((header) => (
                   <TableHead


### PR DESCRIPTION
## Summary
- update table header background color in Material Flow Tracer DataTable

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68807fecfc00832d8f06ce66b8a63edf