### PR TITLE
Add supplier marketplace and scraper

### DIFF
--- a/frontend/src/data/suppliers.json
+++ b/frontend/src/data/suppliers.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 1,
+    "name": "EcoTextiles Ltd",
+    "material": "Cotton Scrap",
+    "ratePerTonne": 1250,
+    "location": "Mumbai"
+  },
+  {
+    "id": 2,
+    "name": "Green Fibers Co",
+    "material": "Polyester Waste",
+    "ratePerTonne": 980,
+    "location": "Delhi"
+  },
+  {
+    "id": 3,
+    "name": "Recycle Hub",
+    "material": "Mixed Fabric",
+    "ratePerTonne": 1100,
+    "location": "Bengaluru"
+  },
+  {
+    "id": 4,
+    "name": "Textile Renew",
+    "material": "Nylon Scrap",
+    "ratePerTonne": 1350,
+    "location": "Hyderabad"
+  }
+]

--- a/frontend/src/pages/Marketplace.tsx
+++ b/frontend/src/pages/Marketplace.tsx
@@ -1,5 +1,42 @@
-import ComingSoon from "@/components/ComingSoon";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import AppLayout from "@/layouts/AppLayout";
+import suppliers from "@/data/suppliers.json";
+
+interface Supplier {
+  id: number;
+  name: string;
+  material: string;
+  ratePerTonne: number;
+  location: string;
+}
 
 export default function Marketplace() {
-  return <ComingSoon title="Marketplace" />;
+  const data = suppliers as Supplier[];
+  return (
+    <AppLayout title="Marketplace">
+      <div className="max-w-4xl mx-auto py-10 space-y-6">
+        <h1 className="text-2xl font-semibold">Supplier Marketplace</h1>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Supplier</TableHead>
+              <TableHead>Material</TableHead>
+              <TableHead>Rate/Tonne (₹)</TableHead>
+              <TableHead>Location</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.map((s) => (
+              <TableRow key={s.id}>
+                <TableCell>{s.name}</TableCell>
+                <TableCell>{s.material}</TableCell>
+                <TableCell>{s.ratePerTonne}</TableCell>
+                <TableCell>{s.location}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </AppLayout>
+  );
 }

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,0 +1,48 @@
+"""Simple scraper to collect supplier data for the marketplace."""
+
+import json
+from typing import List, Dict
+
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://example.com/recycling-market"
+
+
+def fetch_suppliers() -> List[Dict[str, str]]:
+    """Fetch supplier data from an example marketplace page.
+
+    This function demonstrates how the marketplace data could be collected
+    from an online source. The target page is expected to have a table with
+    supplier name, material type and rate per tonne.
+    """
+    resp = requests.get(URL, timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    data: List[Dict[str, str]] = []
+
+    table = soup.find("table")
+    if not table:
+        return data
+
+    for row in table.find_all("tr")[1:]:
+        cols = [c.get_text(strip=True) for c in row.find_all("td")]
+        if len(cols) >= 3:
+            supplier = {
+                "name": cols[0],
+                "material": cols[1],
+                "ratePerTonne": cols[2],
+            }
+            data.append(supplier)
+
+    return data
+
+
+def main() -> None:
+    suppliers = fetch_suppliers()
+    print(json.dumps(suppliers, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement Marketplace page showing suppliers and rates per tonne
- add sample supplier data
- add simple Python scraper script

## Testing
- `pnpm test` *(fails: vitest not found)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6889c936fa80832d86e6afb5b498a61b