### PR TITLE
Improve User Inputs card layout

### DIFF
--- a/frontend/src/pages/UserInputsV2.tsx
+++ b/frontend/src/pages/UserInputsV2.tsx
@@ -145,7 +145,7 @@ export default function UserInputsPage() {
                     {item.description}
                   </p>
                   <div
-                    className={`rounded-full border-4 ${item.color} w-12 h-12 flex items-center justify-center text-sm font-bold`}
+                    className={`rounded-full border-4 ${item.color} w-16 h-16 flex items-center justify-center text-base font-bold`}
                   >
                     {item.score}/10
                   </div>


### PR DESCRIPTION
## Summary
- make the score circle larger in User Inputs cards

## Testing
- `corepack pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6889ee9ceea0832d8139815fed84838e