### PR TITLE
Fix spacing for Settings and Boundary pages

### DIFF
--- a/frontend/src/pages/Boundary.tsx
+++ b/frontend/src/pages/Boundary.tsx
@@ -16,12 +16,13 @@ export default function BoundaryPage() {
 
   return (
     <AppLayout title="Boundary">
-      <Card className="max-w-xl">
-        <CardHeader>
-          <CardTitle>Boundary Settings</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="max-w-xl mx-auto space-y-6 py-10">
+        <Card>
+          <CardHeader>
+            <CardTitle>Boundary Settings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <Label htmlFor="project">Project Name</Label>
               <Input
@@ -38,10 +39,11 @@ export default function BoundaryPage() {
                 onChange={(e) => setFile(e.target.files?.[0] ?? null)}
               />
             </div>
-            <Button type="submit">Save</Button>
-          </form>
-        </CardContent>
-      </Card>
+              <Button type="submit">Save</Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
     </AppLayout>
   );
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -17,12 +17,13 @@ export default function SettingsPage() {
 
   return (
     <AppLayout title="Settings">
-      <Card className="max-w-xl">
-        <CardHeader>
-          <CardTitle>Account Settings</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSave} className="space-y-4">
+      <div className="max-w-xl mx-auto space-y-6 py-10">
+        <Card>
+          <CardHeader>
+            <CardTitle>Account Settings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSave} className="space-y-4">
             <div>
               <Label htmlFor="name">Name</Label>
               <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
@@ -45,10 +46,11 @@ export default function SettingsPage() {
                 onChange={(e) => setPassword(e.target.value)}
               />
             </div>
-            <Button type="submit">Save Changes</Button>
-          </form>
-        </CardContent>
-      </Card>
+              <Button type="submit">Save Changes</Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
     </AppLayout>
   );
 }


### PR DESCRIPTION
## Summary
- center forms on Settings page
- center forms on Boundary page

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm install` *(fails: 403 during package fetch)*

------
https://chatgpt.com/codex/tasks/task_b_6889eefac834832dbdb6c7cfc7001914