### PR TITLE
Update selectors on order tracker page

### DIFF
--- a/frontend/src/pages/OrderTracker.tsx
+++ b/frontend/src/pages/OrderTracker.tsx
@@ -109,7 +109,7 @@ export default function OrderTracker() {
             </Popover>
 
             <Select value={region} onValueChange={setRegion}>
-              <SelectTrigger className="w-[160px]">
+              <SelectTrigger className="w-[160px] bg-white">
                 <SelectValue placeholder="Region" />
               </SelectTrigger>
               <SelectContent>
@@ -120,7 +120,7 @@ export default function OrderTracker() {
             </Select>
 
             <Select value={risk} onValueChange={setRisk}>
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-[180px] bg-white">
                 <SelectValue placeholder="Risk" />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
## Summary
- ensure order tracker page selectors have a white background

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_688a460b2fa4832d8d48c4786a3f0c3c