### PR TITLE
Update grid rows and spacing on Financialization page

### DIFF
--- a/frontend/src/pages/Financialization.tsx
+++ b/frontend/src/pages/Financialization.tsx
@@ -90,7 +90,7 @@ export default function FinancializationPage() {
     <AppLayout title="Green Certification & Finance">
       <div className="p-4 sm:p-6 space-y-4 text-charcoal">
         {/* Centralized Grid Layout */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 md:grid-rows-3 gap-2 items-center justify-center">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 md:grid-rows-2 gap-2 items-center justify-center mb-4">
           {/* Top row */}
           <Card className="p-4 bg-white border rounded-xl shadow-sm md:row-start-1 md:col-start-1 text-center">
             <CardTitle className="text-sm font-semibold">
@@ -171,7 +171,7 @@ export default function FinancializationPage() {
         </div>
 
         {/* Suggestions and Registry */}
-        <div className="flex flex-col lg:flex-row gap-2">
+        <div className="flex flex-col md:flex-col lg:flex-row gap-2">
           {/* Suggestions */}
           <div className="space-y-2 lg:w-1/3">
             <h2 className="text-lg font-semibold">


### PR DESCRIPTION
## Summary
- tweak financialization grid to use two rows
- add margin after grid for spacing
- ensure flex column layout on md for suggestions section

## Testing
- `pnpm install --frozen-lockfile` *(fails: Forbidden 403)*

------
https://chatgpt.com/codex/tasks/task_b_688a6918ebb8832db64acfdb67f0c095