### PR TITLE
Implement pages for credits and certifications

### DIFF
--- a/frontend/src/pages/GreenCertifications.tsx
+++ b/frontend/src/pages/GreenCertifications.tsx
@@ -1,5 +1,54 @@
-import ComingSoon from "@/components/ComingSoon";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import AppLayout from "@/layouts/AppLayout";
+
+const certifications = [
+  { name: "GOTS", focus: "Organic fibres" },
+  { name: "GRS", focus: "Recycled materials" },
+  { name: "Oeko-Tex", focus: "Chemical safety" },
+  { name: "Fair Trade", focus: "Ethical sourcing" },
+];
 
 export default function GreenCertifications() {
-  return <ComingSoon title="Green Certifications" />;
+  return (
+    <AppLayout title="Green Certifications">
+      <div className="max-w-4xl mx-auto space-y-6 py-10">
+        <h1 className="text-2xl font-semibold">Recognized Programs</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Overview</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              Lumen Earth tracks sustainability credentials associated with textile materials.
+              Certifications help verify recycled content, chemical management and social compliance.
+            </p>
+            <p>
+              Below are common certifications supported on the platform. Additional programs can be added on request.
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Focus</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {certifications.map((c) => (
+                  <TableRow key={c.name}>
+                    <TableCell>{c.name}</TableCell>
+                    <TableCell>{c.focus}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </AppLayout>
+  );
 }

--- a/frontend/src/pages/credits/GRSCredits.tsx
+++ b/frontend/src/pages/credits/GRSCredits.tsx
@@ -1,0 +1,80 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import AppLayout from "@/layouts/AppLayout";
+
+interface Transaction {
+  id: string;
+  date: string;
+  quantity: string;
+  type: string;
+}
+
+const transactions: Transaction[] = [
+  { id: "TX-101", date: "2024-05-10", quantity: "500 kg", type: "Issued" },
+  { id: "TX-102", date: "2024-05-18", quantity: "300 kg", type: "Redeemed" },
+  { id: "TX-103", date: "2024-06-02", quantity: "200 kg", type: "Issued" },
+];
+
+export default function GRSCreditsPage() {
+  return (
+    <AppLayout title="GRS Credits">
+      <div className="max-w-4xl mx-auto space-y-6 py-10">
+        <h1 className="text-2xl font-semibold">Global Recycled Standard Credits</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Credit Balance</CardTitle>
+          </CardHeader>
+          <CardContent className="text-3xl font-bold text-green-700">1,250 kg</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Record New Credits</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4">
+              <div>
+                <Label htmlFor="quantity">Quantity (kg)</Label>
+                <Input id="quantity" type="number" placeholder="e.g. 100" />
+              </div>
+              <div>
+                <Label htmlFor="batch">Batch ID</Label>
+                <Input id="batch" placeholder="Batch reference" />
+              </div>
+              <Button type="submit">Add Credits</Button>
+            </form>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent Activity</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Quantity</TableHead>
+                  <TableHead>Type</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {transactions.map((t) => (
+                  <TableRow key={t.id}>
+                    <TableCell>{t.id}</TableCell>
+                    <TableCell>{t.date}</TableCell>
+                    <TableCell>{t.quantity}</TableCell>
+                    <TableCell>{t.type}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </AppLayout>
+  );
+}

--- a/frontend/src/pages/credits/INCCTSOffset.tsx
+++ b/frontend/src/pages/credits/INCCTSOffset.tsx
@@ -1,0 +1,60 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import AppLayout from "@/layouts/AppLayout";
+
+const projects = [
+  { name: "Biomass Boiler Upgrade", region: "Karnataka", price: "₹500/tCO₂e" },
+  { name: "Solar Thermal Installation", region: "Tamil Nadu", price: "₹650/tCO₂e" },
+];
+
+export default function INCCTSOffsetPage() {
+  return (
+    <AppLayout title="INCCTS Offset">
+      <div className="max-w-4xl mx-auto space-y-6 py-10">
+        <h1 className="text-2xl font-semibold">Carbon Offset Marketplace</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Purchase Offsets</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4">
+              <div>
+                <Label htmlFor="quantity">Quantity (tCO₂e)</Label>
+                <Input id="quantity" type="number" placeholder="e.g. 10" />
+              </div>
+              <Button type="submit">Calculate Price</Button>
+            </form>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Available Projects</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Project</TableHead>
+                  <TableHead>Region</TableHead>
+                  <TableHead>Price</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {projects.map((p) => (
+                  <TableRow key={p.name}>
+                    <TableCell>{p.name}</TableCell>
+                    <TableCell>{p.region}</TableCell>
+                    <TableCell>{p.price}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </AppLayout>
+  );
+}

--- a/frontend/src/routes/credits/grs.tsx
+++ b/frontend/src/routes/credits/grs.tsx
@@ -1,4 +1,4 @@
-import ComingSoon from "@/components/ComingSoon";
+import GRSCreditsPage from "@/pages/credits/GRSCredits";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/credits/grs")({
@@ -6,5 +6,5 @@ export const Route = createFileRoute("/credits/grs")({
 });
 
 function RouteComponent() {
-  return <ComingSoon title="GRS Credits" />;
+  return <GRSCreditsPage />;
 }

--- a/frontend/src/routes/credits/offset.tsx
+++ b/frontend/src/routes/credits/offset.tsx
@@ -1,4 +1,4 @@
-import ComingSoon from "@/components/ComingSoon";
+import INCCTSOffsetPage from "@/pages/credits/INCCTSOffset";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/credits/offset")({
@@ -6,5 +6,5 @@ export const Route = createFileRoute("/credits/offset")({
 });
 
 function RouteComponent() {
-  return <ComingSoon title="INCCTS Offset" />;
+  return <INCCTSOffsetPage />;
 }


### PR DESCRIPTION
## Summary
- replace the placeholder `ComingSoon` screens with detailed pages
- add detailed component for GRS credits
- add detailed component for INCCTS offset
- flesh out the Green Certifications page

## Testing
- `pnpm test` *(fails: vitest not found)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_b_688b44f17808832daa9e66da0deacd24