### PR TITLE
Apply custom colors to tracker graphs

### DIFF
--- a/frontend/src/pages/InventoryTracker.tsx
+++ b/frontend/src/pages/InventoryTracker.tsx
@@ -50,9 +50,9 @@ function getDefaultRange(dates: Date[]): DateRange | undefined {
 }
 
 const riskColor = (score: number) => {
-  if (score >= 4) return "bg-red-500 text-white";
-  if (score >= 2) return "bg-yellow-300";
-  return "bg-green-300";
+  if (score >= 4) return "bg-[#cc9aff] text-black";
+  if (score >= 2) return "bg-[#afd14d] text-black";
+  return "bg-[#ff4e4e] text-white";
 };
 
 const InventoryTracker = () => {
@@ -169,16 +169,7 @@ const InventoryTracker = () => {
     }));
   }, [forecastData, dateRange]);
 
-  const chartColors = [
-    "#66c2a5",
-    "#fc8d62",
-    "#8da0cb",
-    "#e78ac3",
-    "#a6d854",
-    "#ffd92f",
-    "#e5c494",
-    "#b3b3b3",
-  ];
+  const chartColors = ["#cc9aff", "#afd14d", "#ff4e4e"];
 
   return (
     <AppLayout title="Inventory Tracker">

--- a/frontend/src/pages/OrderTracker.tsx
+++ b/frontend/src/pages/OrderTracker.tsx
@@ -50,20 +50,12 @@ function getDefaultRange(dates: Date[]): DateRange | undefined {
 }
 
 const riskColor = (score: number) => {
-  if (score >= 4) return "bg-red-500 text-white";
-  if (score >= 2) return "bg-yellow-300";
-  return "bg-green-300";
+  if (score >= 4) return "bg-[#cc9aff] text-black";
+  if (score >= 2) return "bg-[#afd14d] text-black";
+  return "bg-[#ff4e4e] text-white";
 };
 
-const chartColors = [
-  "#db1f26", // red
-  "#e95e27", // orange-red
-  "#c7d730", // yellow-green
-  "#6dc44a", // light green
-  "#66b8db", // sky blue
-  "#a95fd6", // purple
-  "#cc79a7", // pinkish
-];
+const chartColors = ["#cc9aff", "#afd14d", "#ff4e4e"];
 
 const OrderTracker = () => {
   const allInventory = useMemo(


### PR DESCRIPTION
## Summary
- Update inventory tracker heatmap and line chart to use #cc9aff, #afd14d, and #ff4e4e
- Apply same color palette to order tracker graphs

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_688f74df6204832d99bad8d34fb027ce