### PR TITLE
feat(frontend): add API login helper

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,35 @@
+export const API_BASE = '/api';
+
+export interface LoginResponse {
+  token: string;
+  [key: string]: unknown;
+}
+
+export async function login(email: string, password: string): Promise<LoginResponse> {
+  const res = await fetch(`${API_BASE}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  const data = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    const message = (data && (data.message || data.error)) || 'Login failed';
+    throw new Error(message);
+  }
+
+  const { token } = data as LoginResponse;
+  if (!token) {
+    throw new Error('Token not provided');
+  }
+
+  localStorage.setItem('token', token);
+  return data as LoginResponse;
+}
+
+export function logout() {
+  localStorage.removeItem('token');
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
+import { login } from "@/lib/api";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -15,9 +16,10 @@ export default function LoginPage() {
     e.preventDefault();
     setLoading(true);
     try {
+      await login(email, password);
       navigate({ to: `/material-flow-tracer` });
     } catch (err: any) {
-      toast.error("Login failed: " + err.message);
+      toast.error(err.message || "Login failed");
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- add API helper for login/logout and storing tokens
- use login helper in login page and surface API errors

## Testing
- `pnpm test` (fails: No test files found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_b_689053501a8c832d95d6b9711279c222