### PR TITLE
docs: document auth flows

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,14 +2,56 @@
 
 This directory contains a minimal Django project skeleton.
 
-To install dependencies:
+## Setup
+
+1. Create and activate a virtual environment.
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Apply database migrations:
+
+   ```bash
+   python manage.py migrate
+   ```
+4. Run the development server:
+
+   ```bash
+   python manage.py runserver
+   ```
+
+## Authentication
+
+The backend exposes the following authentication endpoints:
+
+| Method | Endpoint          | Description             |
+| ------ | ----------------- | ----------------------- |
+| POST   | `/auth/register/` | Register a new user     |
+| POST   | `/auth/login/`    | Obtain an auth token    |
+| POST   | `/auth/logout/`   | Invalidate the session  |
+
+### Example requests
+
+Register a user:
 
 ```bash
-pip install -r requirements.txt
+curl -X POST http://localhost:8000/auth/register/ \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"user@example.com","password":"secret"}'
 ```
 
-To run the development server:
+Log in:
 
 ```bash
-python manage.py runserver
+curl -X POST http://localhost:8000/auth/login/ \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"user@example.com","password":"secret"}'
+```
+
+Log out:
+
+```bash
+curl -X POST http://localhost:8000/auth/logout/ \
+  -H "Authorization: Token <token>"
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,8 +6,14 @@ To run this application:
 
 ```bash
 pnpm install
-pnpm start  
+pnpm start
 ```
+
+# Authentication
+
+- **Register**: Visit `http://localhost:5173/register` and complete the form to create a new account.
+- **Login**: Navigate to `http://localhost:5173/login`, enter your credentials, and submit the form.
+- **Logout**: Use the user menu in the application header and select **Logout** to end your session.
 
 # Building For Production
 


### PR DESCRIPTION
## Summary
- expand backend README with setup steps and example auth requests
- add frontend README instructions for registering, logging in, and logging out

## Testing
- `python backend/manage.py test`
- `cd frontend && pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_689053537d58832d9daa2cf44f4dbc05