### PR TITLE
Add authentication endpoints

### DIFF
--- a/backend/accounts/apps.py
+++ b/backend/accounts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'accounts'

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import User
+from rest_framework import serializers
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+
+class RegisterSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'password')
+
+    def create(self, validated_data):
+        return User.objects.create_user(
+            username=validated_data['username'],
+            password=validated_data['password'],
+        )
+
+
+class LoginSerializer(TokenObtainPairSerializer):
+    pass

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1,0 +1,22 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class AuthenticationTests(APITestCase):
+    def test_registration_login_and_protected_access(self):
+        register_url = reverse('register')
+        credentials = {'username': 'tester', 'password': 'secret123'}
+
+        resp = self.client.post(register_url, credentials, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        login_url = reverse('login')
+        resp = self.client.post(login_url, credentials, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        access_token = resp.data['access']
+
+        protected_url = reverse('protected')
+        resp = self.client.get(protected_url, HTTP_AUTHORIZATION=f'Bearer {access_token}')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['detail'], 'success')

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+from rest_framework_simplejwt.views import TokenRefreshView, TokenObtainPairView
+
+from .serializers import LoginSerializer
+from .views import RegisterView, ProtectedView
+
+
+class LoginView(TokenObtainPairView):
+    serializer_class = LoginSerializer
+
+
+urlpatterns = [
+    path('register', RegisterView.as_view(), name='register'),
+    path('login', LoginView.as_view(), name='login'),
+    path('refresh', TokenRefreshView.as_view(), name='token_refresh'),
+    path('protected', ProtectedView.as_view(), name='protected'),
+]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,0 +1,20 @@
+from django.contrib.auth.models import User
+from rest_framework import generics, permissions
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+
+from .serializers import RegisterSerializer
+
+
+class RegisterView(generics.CreateAPIView):
+    queryset = User.objects.all()
+    serializer_class = RegisterSerializer
+    permission_classes = [permissions.AllowAny]
+
+
+class ProtectedView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response({'detail': 'success'})

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -19,6 +19,8 @@ INSTALLED_APPS = [
     'raw_data',
     'process_data',
     'output_data',
+    'rest_framework',
+    'accounts',
 ]
 
 MIDDLEWARE = [
@@ -80,3 +82,9 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    )
+}

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from main import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', views.index, name='index'),
+    path('api/auth/', include('accounts.urls')),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,3 @@
 django>=4.2
+djangorestframework
+djangorestframework-simplejwt


### PR DESCRIPTION
## Summary
- add accounts app with registration endpoint and JWT login/refresh
- integrate SimpleJWT and DRF into settings and project urls
- test registration, login, and authenticated access

## Testing
- `python manage.py test accounts` *(fails: ModuleNotFoundError: No module named 'rest_framework')*


------
https://chatgpt.com/codex/tasks/task_b_6890534f7860832d81427042738bfa0a