### PR TITLE
Use register path on login page

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -97,7 +97,7 @@ export default function LoginPage() {
           <p className="text-sm text-center text-charcoal/70">
             Don’t have an account?{" "}
             <a
-              href="/signup"
+              href="/register"
               className="text-primary font-medium hover:underline"
             >
               Sign up


### PR DESCRIPTION
## Summary
- Fix login page to link to `/register` instead of `/signup`

## Testing
- `npm test` (fails: No test files found)
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_689051e3e8dc832d8c8bc09460f48715